### PR TITLE
Feature/trips/refresh

### DIFF
--- a/app/src/main/java/ca/llamabagel/transpo/ui/trips/StopFragment.kt
+++ b/app/src/main/java/ca/llamabagel/transpo/ui/trips/StopFragment.kt
@@ -13,7 +13,10 @@ import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.RecyclerView
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import ca.llamabagel.transpo.R
+import ca.llamabagel.transpo.ui.trips.adapter.TripAdapterItem
+import ca.llamabagel.transpo.ui.trips.adapter.TripItem
 import ca.llamabagel.transpo.ui.trips.adapter.TripsAdapter
 
 class StopFragment : Fragment() {
@@ -24,31 +27,36 @@ class StopFragment : Fragment() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.stop_fragment, container, false)
-    }
+    ): View? = inflater.inflate(R.layout.stop_fragment, container, false)
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        viewModel.displayData.observe(this, Observer { data ->
-            data ?: return@Observer
+        val adapter = TripsAdapter(itemClickListener = ::itemSelected)
+        view.findViewById<RecyclerView>(R.id.recycler_view).adapter = adapter
 
-            view.findViewById<RecyclerView>(R.id.recycler_view).adapter = TripsAdapter(data,
-                itemClickListener = { item ->
-                    when (item) {
-                        is TripItem -> {
-                            viewModel.updateRouteSelection(
-                                item.tripUiModel.route.number,
-                                item.tripUiModel.route.directionId,
-                                true
-                            )
-                            findNavController().navigate(R.id.tripsFragment)
-                        }
-                    }
-                })
+        viewModel.isRefreshing.observe(this, Observer { isRefreshing ->
+            view.findViewById<SwipeRefreshLayout>(R.id.swipe_refresh).isRefreshing = isRefreshing
         })
+
+        viewModel.displayData.observe(this, Observer(adapter::submitList))
+
+        view.findViewById<SwipeRefreshLayout>(R.id.swipe_refresh).setOnRefreshListener {
+            viewModel.getTrips()
+        }
+    }
+
+    private fun itemSelected(item: TripAdapterItem) {
+        when (item) {
+            is TripItem -> {
+                viewModel.updateRouteSelection(
+                    item.tripUiModel.route.number,
+                    item.tripUiModel.route.directionId,
+                    true
+                )
+                findNavController().navigate(R.id.tripsFragment)
+            }
+        }
     }
 
     companion object {

--- a/app/src/main/java/ca/llamabagel/transpo/ui/trips/TripAdapterItem.kt
+++ b/app/src/main/java/ca/llamabagel/transpo/ui/trips/TripAdapterItem.kt
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 2019 Derek Ellis. Subject to the MIT license.
- */
-
-package ca.llamabagel.transpo.ui.trips
-
-sealed class TripAdapterItem
-
-data class TripItem(val tripUiModel: TripUiModel) : TripAdapterItem()

--- a/app/src/main/java/ca/llamabagel/transpo/ui/trips/TripsFragment.kt
+++ b/app/src/main/java/ca/llamabagel/transpo/ui/trips/TripsFragment.kt
@@ -15,6 +15,7 @@ import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.RecyclerView
 import ca.llamabagel.transpo.BuildConfig
 import ca.llamabagel.transpo.R
+import ca.llamabagel.transpo.ui.trips.adapter.TripItem
 import ca.llamabagel.transpo.ui.trips.adapter.TripsAdapter
 import com.mapbox.geojson.Feature
 import com.mapbox.geojson.MultiPoint
@@ -44,19 +45,15 @@ class TripsFragment : Fragment() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.trips_fragment, container, false)
-    }
+    ): View? = inflater.inflate(R.layout.trips_fragment, container, false)
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        viewModel.viewerData.observe(this, Observer {
-            view.findViewById<RecyclerView>(R.id.recycler_view).apply {
-                adapter = TripsAdapter(it)
-            }
-        })
+        val adapter = TripsAdapter()
+        view.findViewById<RecyclerView>(R.id.recycler_view).adapter = adapter
+
+        viewModel.viewerData.observe(this, Observer(adapter::submitList))
 
         val mapView = view.findViewById<MapView>(R.id.map_view)
         mapView.onCreate(savedInstanceState)

--- a/app/src/main/java/ca/llamabagel/transpo/ui/trips/TripsViewModel.kt
+++ b/app/src/main/java/ca/llamabagel/transpo/ui/trips/TripsViewModel.kt
@@ -13,6 +13,8 @@ import ca.llamabagel.transpo.data.Result
 import ca.llamabagel.transpo.data.TripsRepository
 import ca.llamabagel.transpo.data.db.Stop
 import ca.llamabagel.transpo.models.trips.ApiResponse
+import ca.llamabagel.transpo.ui.trips.adapter.TripAdapterItem
+import ca.llamabagel.transpo.ui.trips.adapter.TripItem
 import ca.llamabagel.transpo.utils.TAG
 import ca.llamabagel.transpo.ui.trips.adapter.TripsAdapter
 import kotlinx.coroutines.launch
@@ -21,6 +23,9 @@ import javax.inject.Inject
 class TripsViewModel @Inject constructor(private val tripsRepository: TripsRepository) : ViewModel() {
 
     private lateinit var apiData: Result<ApiResponse>
+
+    private val _isRefreshing = MutableLiveData<Boolean>()
+    val isRefreshing: LiveData<Boolean> = _isRefreshing
 
     private val _stop = MutableLiveData<Stop?>()
     val stop: LiveData<Stop?> = _stop
@@ -40,8 +45,10 @@ class TripsViewModel @Inject constructor(private val tripsRepository: TripsRepos
     fun getTrips() = viewModelScope.launch {
         if (_stop.value == null) {
             Log.i(TAG, "No stop loaded")
+            return@launch
         }
 
+        _isRefreshing.value = true
         apiData = tripsRepository.getTrips(_stop.value!!.code)
 
         when (val copy = apiData) {
@@ -57,6 +64,7 @@ class TripsViewModel @Inject constructor(private val tripsRepository: TripsRepos
                 // TODO: Handle errors
             }
         }
+        _isRefreshing.value = false
     }
 
     fun updateRouteSelection(number: String, directionId: Int, selected: Boolean) {

--- a/app/src/main/java/ca/llamabagel/transpo/ui/trips/adapter/RouteViewHolder.kt
+++ b/app/src/main/java/ca/llamabagel/transpo/ui/trips/adapter/RouteViewHolder.kt
@@ -7,7 +7,6 @@ package ca.llamabagel.transpo.ui.trips.adapter
 import androidx.databinding.ViewDataBinding
 import androidx.recyclerview.widget.RecyclerView
 import ca.llamabagel.transpo.models.trips.Route
-import ca.llamabagel.transpo.ui.trips.TripAdapterItem
 
 class RouteViewHolder(
     private val binding: ViewDataBinding,

--- a/app/src/main/java/ca/llamabagel/transpo/ui/trips/adapter/SingleTripViewHolder.kt
+++ b/app/src/main/java/ca/llamabagel/transpo/ui/trips/adapter/SingleTripViewHolder.kt
@@ -6,8 +6,6 @@ package ca.llamabagel.transpo.ui.trips.adapter
 
 import androidx.recyclerview.widget.RecyclerView
 import ca.llamabagel.transpo.databinding.TripBinding
-import ca.llamabagel.transpo.ui.trips.TripAdapterItem
-import ca.llamabagel.transpo.ui.trips.TripItem
 import ca.llamabagel.transpo.ui.trips.TripUiModel
 
 class SingleTripViewHolder(

--- a/app/src/main/java/ca/llamabagel/transpo/ui/trips/adapter/TripAdapterItem.kt
+++ b/app/src/main/java/ca/llamabagel/transpo/ui/trips/adapter/TripAdapterItem.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2019 Derek Ellis. Subject to the MIT license.
+ */
+
+package ca.llamabagel.transpo.ui.trips.adapter
+
+import android.annotation.SuppressLint
+import androidx.recyclerview.widget.DiffUtil
+import ca.llamabagel.transpo.ui.trips.TripUiModel
+
+sealed class TripAdapterItem {
+    abstract infix fun sameAs(other: TripAdapterItem): Boolean
+
+    companion object {
+        val DIFF_CALLBACK = object : DiffUtil.ItemCallback<TripAdapterItem>() {
+
+            override fun areItemsTheSame(oldItem: TripAdapterItem, newItem: TripAdapterItem): Boolean =
+                oldItem sameAs newItem
+
+            @SuppressLint("DiffUtilEquals")
+            override fun areContentsTheSame(oldItem: TripAdapterItem, newItem: TripAdapterItem): Boolean {
+                return oldItem == newItem
+            }
+        }
+    }
+}
+
+data class TripItem(val tripUiModel: TripUiModel) : TripAdapterItem() {
+    override infix fun sameAs(other: TripAdapterItem): Boolean {
+        if (other !is TripItem) return false
+
+        return other.tripUiModel.route.number == tripUiModel.route.number &&
+                other.tripUiModel.route.directionId == tripUiModel.route.directionId &&
+                other.tripUiModel.trip.startTime == tripUiModel.trip.startTime
+    }
+}
+

--- a/app/src/main/java/ca/llamabagel/transpo/ui/trips/adapter/TripsAdapter.kt
+++ b/app/src/main/java/ca/llamabagel/transpo/ui/trips/adapter/TripsAdapter.kt
@@ -7,17 +7,15 @@ package ca.llamabagel.transpo.ui.trips.adapter
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import ca.llamabagel.transpo.R
 import ca.llamabagel.transpo.databinding.TripBinding
-import ca.llamabagel.transpo.ui.trips.TripAdapterItem
-import ca.llamabagel.transpo.ui.trips.TripItem
 
 class TripsAdapter(
-    private val items: List<TripAdapterItem>,
     private val itemClickListener: (TripAdapterItem) -> Unit = {},
     private val itemSelectionListener: (TripAdapterItem, Boolean) -> Unit = { _, _ -> }
-) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+) : ListAdapter<TripAdapterItem, RecyclerView.ViewHolder>(TripAdapterItem.DIFF_CALLBACK) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         val layoutInflater = LayoutInflater.from(parent.context)
@@ -31,15 +29,14 @@ class TripsAdapter(
         }
     }
 
-    override fun getItemViewType(position: Int): Int = when (items[position]) {
+    override fun getItemViewType(position: Int): Int = when (getItem(position)) {
         is TripItem -> R.layout.trip
     }
 
-    override fun getItemCount(): Int = items.size
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         when (holder) {
-            is SingleTripViewHolder -> holder.bind((items[position] as TripItem).tripUiModel)
+            is SingleTripViewHolder -> holder.bind((getItem(position) as TripItem).tripUiModel)
         }
     }
 }

--- a/app/src/main/java/ca/llamabagel/transpo/utils/ListDiffResult.kt
+++ b/app/src/main/java/ca/llamabagel/transpo/utils/ListDiffResult.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2019 Derek Ellis. Subject to the MIT license.
+ */
+
+package ca.llamabagel.transpo.utils
+
+import androidx.recyclerview.widget.DiffUtil
+
+data class ListDiffResult<T : Any>(val list: List<T> = emptyList(), val diffResult: DiffUtil.DiffResult = EMPTY_RESULT)
+
+private val EMPTY_RESULT = DiffUtil.calculateDiff(object : DiffUtil.Callback() {
+    override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean = throw AssertionError()
+
+    override fun getOldListSize(): Int = 0
+
+    override fun getNewListSize(): Int = 0
+
+    override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean = throw AssertionError()
+})

--- a/app/src/main/java/ca/llamabagel/transpo/utils/ListDiffResult.kt
+++ b/app/src/main/java/ca/llamabagel/transpo/utils/ListDiffResult.kt
@@ -6,9 +6,9 @@ package ca.llamabagel.transpo.utils
 
 import androidx.recyclerview.widget.DiffUtil
 
-data class ListDiffResult<T : Any>(val list: List<T> = emptyList(), val diffResult: DiffUtil.DiffResult = EMPTY_RESULT)
+data class ListDiffResult<T : Any>(val list: List<T> = emptyList(), val diffResult: DiffUtil.DiffResult = EmptyResult)
 
-private val EMPTY_RESULT = DiffUtil.calculateDiff(object : DiffUtil.Callback() {
+private val EmptyResult = DiffUtil.calculateDiff(object : DiffUtil.Callback() {
     override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean = throw AssertionError()
 
     override fun getOldListSize(): Int = 0

--- a/app/src/main/res/layout/activity_trips.xml
+++ b/app/src/main/res/layout/activity_trips.xml
@@ -30,7 +30,7 @@
                 app:layout_constraintTop_toTopOf="parent"/>
 
         <fragment
-                android:layout_width="match_parent"
+                android:layout_width="0dp"
                 android:layout_height="0dp"
                 android:id="@+id/nav_host_fragment"
                 app:layout_constraintLeft_toLeftOf="parent"

--- a/app/src/main/res/layout/stop_fragment.xml
+++ b/app/src/main/res/layout/stop_fragment.xml
@@ -10,15 +10,20 @@
         android:layout_height="match_parent"
         tools:context="ca.llamabagel.transpo.ui.trips.StopFragment">
 
-    <androidx.recyclerview.widget.RecyclerView
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
             android:layout_width="0dp"
             android:layout_height="0dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            android:id="@+id/recycler_view"
-            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintTop_toTopOf="parent"
-            />
+            android:id="@+id/swipe_refresh">
+
+        <androidx.recyclerview.widget.RecyclerView
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:id="@+id/recycler_view"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"/>
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
# Checklist
- [x] I ran `./gradlew test connectedAndroidTest detekt`
- [x] I rebased off of `upstream/master`
- [ ] At least 1 approving review - **@dellisd**, **@GustavoSanMartin**

# Issues
Closes #37 

# Summary
TripsAdapter is now an implementation of `ListAdapter` which can automatically diff items that are submitted to it. The TripAdapterItem class has a `DiffUtil.ItemCallback` attached to its companion object for this.

Pull to refresh now works on the Stop fragment and results are updated via the diff automatically.

ListDiffResult is not needed for this thanks to the ListAdapter, however it will be needed for a MapAdapter later on so I figured I'd just include it anyway.
