### PR TITLE
Use local.properties for config keys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
           key: jars-{{ checksum "build.gradle.kts" }}-{{ checksum  "app/build.gradle.kts" }}
       - run:
           name: Setup local config
-          command: echo -e "api.endpoint=$API_ENDPOINT\nmapbox.key=$MAPBOX_KEY" > config.properties
+          command: echo -e "api.endpoint=$API_ENDPOINT\nmapbox.key=$MAPBOX_KEY" > local.properties
       - run:
           name: Download Dependencies
           command: ./gradlew androidDependencies

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ The open source project behind Route 613. Next stop: 2.0!
 This is a complete open source rewrite of Route 613. The main objective of this rewrite is to adopt a better architecture to improve the reliability of the app and make it easier to add new features.
 
 ## Development Setup
-Development on this project requires Android Studio 3.4 or newer, as well as the Android SDK for Android P (28).
+Development on this project requires Android Studio 3.4 or newer, as well as the Android SDK for Android Q (29).
 
-The built setup requires a `config.properties` file to be created in the root directory of the project that includes configuration information for the API backend and for using the Mapbox SDK.  
-The configuration must include:
+The build setup requires some configuration values in your `local.properties` file to configure information for the API backend and for the Mapbox SDK.  
+The following properties must be included:
 * `api.endpoint` - The base URL of the API endpoint being used. This would direct towards a hosted instance of [transpo-server](https://github.com/dellisd/transpo-server).
 * `mapbox.key` - An API Access Token for using the Mapbox SDK. [You can get one from Mapbox.](https://docs.mapbox.com/help/how-mapbox-works/access-tokens/)


### PR DESCRIPTION
Added basic error handling in gradle build script when checking for config key values
Updated README

# Checklist
- [x] I ran `./gradlew test connectedAndroidTest detekt`
- [x] I rebased off of `upstream/master`
- [x] I added tests if applicable